### PR TITLE
Add libavcodec 58 and libavutil 56

### DIFF
--- a/com.obsproject.Studio.Plugin.NDI.json
+++ b/com.obsproject.Studio.Plugin.NDI.json
@@ -61,6 +61,57 @@
             ]
         },
         {
+            "name": "ffmpeg4.4",
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig",
+                "/lib/libavcodec.so",
+                "/lib/libavutil.so",
+                "/share/ffmpeg"
+            ],
+            "config-opts": [
+                "--disable-static",
+                "--disable-doc",
+                "--disable-programs",
+                "--disable-devices",
+                "--enable-shared",
+                "--disable-avdevice",
+                "--disable-avformat",
+                "--disable-swresample",
+                "--disable-swscale",
+                "--disable-postproc",
+                "--disable-avfilter",
+                "--enable-pthreads",
+                "--disable-alsa",
+                "--disable-bzlib",
+                "--disable-iconv",
+                "--disable-libxcb-shm",
+                "--disable-libxcb-xfixes",
+                "--disable-libxcb-shape",
+                "--disable-lzma",
+                "--disable-sdl2",
+                "--disable-xlib",
+                "--disable-zlib",
+                "--disable-v4l2-m2m",
+                "--disable-ffnvcodec",
+                "--disable-nvdec",
+                "--disable-nvenc",
+                "--enable-vaapi",
+                "--enable-vdpau",
+                "--enable-libopus",
+                "--enable-libopenh264"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/FFmpeg/FFmpeg.git",
+                    "tag": "n4.4.4",
+                    "commit": "71fb6132637a2a430375c24afc381fff8b854fe7",
+                    "disable-shallow-clone": true
+                }
+            ]
+        },
+        {
             "name": "obs-ndi",
             "buildsystem": "cmake-ninja",
             "builddir": true,


### PR DESCRIPTION
Required to enable NDI|XH features

https://github.com/obs-ndi/obs-ndi/issues/724#issuecomment-1817782905

Found inside libndi with a hex editor:
```
libavcodec.so.58
libavcodec-ndi.so.58
libavutil.so.56
libavutil-ndi.so.56

avcodec_alloc_context3
avcodec_find_decoder
avcodec_find_decoder_by_name
avcodec_free_context
avcodec_open2
avcodec_receive_frame
avcodec_send_packet
av_init_packet
av_frame_alloc
av_frame_free
av_frame_move_ref
av_frame_unref
av_frame_copy_props
av_buffer_unref
av_get_default_channel_layout
```

**NOTE: NVIDIA HW codec is not enabled because 4.4.4 does not support latest headers and I don't want to maintain patches**